### PR TITLE
with-group-collapsed missing do

### DIFF
--- a/src/shodan/console.clj
+++ b/src/shodan/console.clj
@@ -17,7 +17,7 @@
   [title & body]
   `(do
      (.groupCollapsed js/console ~title)
-     (let [result# ~@body]
+     (let [result# (do ~@body)]
        (.groupEnd js/console)
        result#)))
  


### PR DESCRIPTION
Need to wrap splatted `body` forms with `do` because body can contain multiple statements
