### PR TITLE
Fix console/error

### DIFF
--- a/src/shodan/console.clj
+++ b/src/shodan/console.clj
@@ -65,7 +65,7 @@
 (defmacro error
   "Like `log` but marks the output as an error."
   [& args]
-  `(.-error js/console ~@args))
+  `(.error js/console ~@args))
 
 (defmacro error*
   "Like `error` but takes a collection and uses apply."


### PR DESCRIPTION
We are calling method, not accessing property

Fixes compilation error:

```
Caused by: java.lang.Error: Unknown dot form of (. js/console -error (p1__27166#)) with classification [:cljs.analyzer/expr :cljs.analyzer/property :cljs.analyzer/expr]
```
