### PR TITLE
Add omitted ] to 'inspect' example

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ console:
 
 ```clojure
 (ns omfg
-  (:require [shodan.inspection :refer [inspect]))
+  (:require [shodan.inspection :refer [inspect]]))
 ```
 
 Use it just like you would clojure's `clojure.pprint/pprint`:


### PR DESCRIPTION
For the good of copy-pasters everywhere, I fixed an unbalanced set of brackets.